### PR TITLE
Use more lenient KSep for non-inverted depth.

### DIFF
--- a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
+++ b/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
@@ -31,8 +31,12 @@ FfxFloat32 ComputeSampleDepthClip(FFX_MIN16_I2 iPxSamplePos, FfxFloat32 fPreviou
     const FfxFloat32 fHalfViewportWidth = RenderSize().x * 0.5f;
     FfxFloat32 fDepthThreshold = ffxMin(fCurrentDepthViewSpace, fPrevNearestDepthViewSpace);
 
+#if !FFX_FSR2_OPTION_INVERTED_DEPTH
+    const FfxFloat32 Ksep = 4.0f * 1.37e-05f; // Arbitrary hack to make normal depth work better.
+#else
     // WARNING: Ksep only works with reversed-z with infinite projection.
     const FfxFloat32 Ksep = 1.37e-05f;
+#endif
     FfxFloat32 fRequiredDepthSeparation = Ksep * fDepthThreshold * TanHalfFoV() * fHalfViewportWidth;
     FfxFloat32 fDepthDiff = fCurrentDepthViewSpace - fPrevNearestDepthViewSpace;
 


### PR DESCRIPTION
Getting some false depth clip values otherwise.

Horrible hack, no idea what the correct solution is, feel free to do something else, but I think this value needs to consider non-inverted depth as well. Just hacked at it until it looked okay in my integration.