### PR TITLE
Fix invalid ptr memset in fsr2GetPermutationBlobByIndex

### DIFF
--- a/src/ffx-fsr2-api/dx12/shaders/ffx_fsr2_shaders_dx12.cpp
+++ b/src/ffx-fsr2-api/dx12/shaders/ffx_fsr2_shaders_dx12.cpp
@@ -388,6 +388,6 @@ FfxErrorCode fsr2GetPermutationBlobByIndex(
     }
 
     // return an empty blob
-    memset(&outBlob, 0, sizeof(Fsr2ShaderBlobDX12));
+    memset(outBlob, 0, sizeof(Fsr2ShaderBlobDX12));
     return FFX_OK;
 }


### PR DESCRIPTION
Fix an invalid ptr memset on empty blob case in fsr2GetPermutationBlobByIndex(), from wrong pointer indirection. This causes crashes from buffer overrun by writing and reading invalid memory.

Thanks to Jason Gorski for this find and fix.