### PR TITLE
Update ffx_fsr2_shaders_dx12.cpp

### DIFF
--- a/src/ffx-fsr2-api/dx12/shaders/ffx_fsr2_shaders_dx12.cpp
+++ b/src/ffx-fsr2-api/dx12/shaders/ffx_fsr2_shaders_dx12.cpp
@@ -388,6 +388,6 @@ FfxErrorCode fsr2GetPermutationBlobByIndex(
     }
 
     // return an empty blob
-    memset(&outBlob, 0, sizeof(Fsr2ShaderBlobDX12));
+    memset(outBlob, 0, sizeof(Fsr2ShaderBlobDX12));
     return FFX_OK;
 }


### PR DESCRIPTION
Fixed buffer overrun.  outBlob is a pointer so using &outBlob causes the memset to write 72 bytes to the 8 byte location of the pointer rather than the location of the struct pointed to by the pointer.