### PR TITLE
Add const to wchar_t* name parameter of ffxGetResourceDX12

### DIFF
--- a/src/ffx-fsr2-api/dx12/ffx_fsr2_dx12.cpp
+++ b/src/ffx-fsr2-api/dx12/ffx_fsr2_dx12.cpp
@@ -323,7 +323,7 @@ FfxSurfaceFormat ffxGetSurfaceFormatDX12(DXGI_FORMAT format)
 }
 
 // register a DX12 resource to the backend
-FfxResource ffxGetResourceDX12(FfxFsr2Context* context, ID3D12Resource* dx12Resource, wchar_t* name, FfxResourceStates state, UINT shaderComponentMapping)
+FfxResource ffxGetResourceDX12(FfxFsr2Context* context, ID3D12Resource* dx12Resource, const wchar_t* name, FfxResourceStates state, UINT shaderComponentMapping)
 {
     FfxResource resource = {};
     resource.resource = reinterpret_cast<void*>(dx12Resource);

--- a/src/ffx-fsr2-api/dx12/ffx_fsr2_dx12.h
+++ b/src/ffx-fsr2-api/dx12/ffx_fsr2_dx12.h
@@ -93,7 +93,7 @@ FFX_API FfxCommandList ffxGetCommandListDX12(ID3D12CommandList* cmdList);
 FFX_API FfxResource ffxGetResourceDX12(
     FfxFsr2Context* context,
     ID3D12Resource* resDx12,
-    wchar_t* name = nullptr,
+    const wchar_t* name = nullptr,
     FfxResourceStates state = FFX_RESOURCE_STATE_COMPUTE_READ,
     UINT shaderComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING);
 


### PR DESCRIPTION
Recent toolsets/compilers will complain if passing a string literal as a `wchar_t*` as opposed to a `const wchar_t*`. As the inner function makes no modifications to `name`, there are no functional changes. The specific v143 VS 2022 compiler error is C2664:

```
Error   C2664   'FfxResource ffxGetResourceDX12(FfxFsr2Context *,ID3D12Resource *,wchar_t *,FfxResourceStates,UINT)': cannot convert argument 3 from 'const wchar_t [17]' to 'wchar_t *'
```