### PR TITLE
Add FfxFsr2Pass to FfxPipelineState

### DIFF
--- a/src/ffx-fsr2-api/ffx_fsr2.cpp
+++ b/src/ffx-fsr2-api/ffx_fsr2.cpp
@@ -179,7 +179,7 @@ static float halton(int32_t index, int32_t base)
     return result;
 }
 
-static FfxErrorCode patchResourceBindings(FfxPipelineState* inoutPipeline)
+static FfxErrorCode patchResourceBindingsAndPassID(FfxPipelineState* inoutPipeline, FfxFsr2Pass passId)
 {
     for (uint32_t srvIndex = 0; srvIndex < inoutPipeline->srvCount; ++srvIndex)
     {
@@ -223,6 +223,8 @@ static FfxErrorCode patchResourceBindings(FfxPipelineState* inoutPipeline)
         inoutPipeline->cbResourceBindings[cbIndex].resourceIdentifier = cbResourceBindingTable[mapIndex].index;
     }
 
+    inoutPipeline->passId = passId;
+
     return FFX_OK;
 }
 
@@ -263,15 +265,15 @@ static FfxErrorCode createPipelineStates(FfxFsr2Context_Private* context)
     FFX_VALIDATE(context->contextDescription.callbacks.fpCreatePipeline(&context->contextDescription.callbacks, FFX_FSR2_PASS_GENERATE_REACTIVE, &pipelineDescription, &context->pipelineGenerateReactive));
     
     // for each pipeline: re-route/fix-up IDs based on names
-    patchResourceBindings(&context->pipelinePrepareInputColor);
-    patchResourceBindings(&context->pipelineDepthClip);
-    patchResourceBindings(&context->pipelineReconstructPreviousDepth);
-    patchResourceBindings(&context->pipelineLock);
-    patchResourceBindings(&context->pipelineAccumulate);
-    patchResourceBindings(&context->pipelineComputeLuminancePyramid);
-    patchResourceBindings(&context->pipelineAccumulateSharpen);
-    patchResourceBindings(&context->pipelineRCAS);
-    patchResourceBindings(&context->pipelineGenerateReactive);
+    patchResourceBindingsAndPassID(&context->pipelinePrepareInputColor,        FFX_FSR2_PASS_PREPARE_INPUT_COLOR);
+    patchResourceBindingsAndPassID(&context->pipelineDepthClip,                FFX_FSR2_PASS_DEPTH_CLIP);
+    patchResourceBindingsAndPassID(&context->pipelineReconstructPreviousDepth, FFX_FSR2_PASS_RECONSTRUCT_PREVIOUS_DEPTH);
+    patchResourceBindingsAndPassID(&context->pipelineLock,                     FFX_FSR2_PASS_LOCK);
+    patchResourceBindingsAndPassID(&context->pipelineAccumulate,               FFX_FSR2_PASS_ACCUMULATE);
+    patchResourceBindingsAndPassID(&context->pipelineComputeLuminancePyramid,  FFX_FSR2_PASS_COMPUTE_LUMINANCE_PYRAMID);
+    patchResourceBindingsAndPassID(&context->pipelineAccumulateSharpen,        FFX_FSR2_PASS_ACCUMULATE_SHARPEN);
+    patchResourceBindingsAndPassID(&context->pipelineRCAS,                     FFX_FSR2_PASS_RCAS);
+    patchResourceBindingsAndPassID(&context->pipelineGenerateReactive,         FFX_FSR2_PASS_GENERATE_REACTIVE);
 
     return FFX_OK;
 }

--- a/src/ffx-fsr2-api/ffx_fsr2_interface.h
+++ b/src/ffx-fsr2-api/ffx_fsr2_interface.h
@@ -36,38 +36,6 @@ extern "C" {
 
 FFX_FORWARD_DECLARE(FfxFsr2Interface);
 
-/// An enumeration of all the passes which constitute the FSR2 algorithm.
-///
-/// FSR2 is implemented as a composite of several compute passes each
-/// computing a key part of the final result. Each call to the 
-/// <c><i>FfxFsr2ScheduleGpuJobFunc</i></c> callback function will
-/// correspond to a single pass included in <c><i>FfxFsr2Pass</i></c>. For a
-/// more comprehensive description of each pass, please refer to the FSR2
-/// reference documentation.
-///
-/// Please note in some cases e.g.: <c><i>FFX_FSR2_PASS_ACCUMULATE</i></c>
-/// and <c><i>FFX_FSR2_PASS_ACCUMULATE_SHARPEN</i></c> either one pass or the
-/// other will be used (they are mutually exclusive). The choice of which will
-/// depend on the way the <c><i>FfxFsr2Context</i></c> is created and the
-/// precise contents of <c><i>FfxFsr2DispatchParamters</i></c> each time a call
-/// is made to <c><i>ffxFsr2ContextDispatch</i></c>.
-/// 
-/// @ingroup FSR2
-typedef enum FfxFsr2Pass {
-
-    FFX_FSR2_PASS_PREPARE_INPUT_COLOR = 0,                              ///< A pass which prepares input colors for subsequent use.
-    FFX_FSR2_PASS_DEPTH_CLIP = 1,                                       ///< A pass which performs depth clipping.
-    FFX_FSR2_PASS_RECONSTRUCT_PREVIOUS_DEPTH = 2,                       ///< A pass which performs reconstruction of previous frame's depth.
-    FFX_FSR2_PASS_LOCK = 3,                                             ///< A pass which calculates pixel locks.
-    FFX_FSR2_PASS_ACCUMULATE = 4,                                       ///< A pass which performs upscaling.
-    FFX_FSR2_PASS_ACCUMULATE_SHARPEN = 5,                               ///< A pass which performs upscaling when sharpening is used.
-    FFX_FSR2_PASS_RCAS = 6,                                             ///< A pass which performs sharpening.
-    FFX_FSR2_PASS_COMPUTE_LUMINANCE_PYRAMID = 7,                        ///< A pass which generates the luminance mipmap chain for the current frame.
-    FFX_FSR2_PASS_GENERATE_REACTIVE = 8,                                ///< An optional pass to generate a reactive mask
-
-    FFX_FSR2_PASS_COUNT                                                 ///< The number of passes performed by FSR2.
-} FfxFsr2Pass;
-
 /// Create and initialize the backend context.
 ///
 /// The callback function sets up the backend context for rendering.

--- a/src/ffx-fsr2-api/ffx_types.h
+++ b/src/ffx-fsr2-api/ffx_types.h
@@ -50,6 +50,38 @@
 extern "C" {
 #endif  // #ifdef __cplusplus
 
+/// An enumeration of all the passes which constitute the FSR2 algorithm.
+///
+/// FSR2 is implemented as a composite of several compute passes each
+/// computing a key part of the final result. Each call to the 
+/// <c><i>FfxFsr2ScheduleGpuJobFunc</i></c> callback function will
+/// correspond to a single pass included in <c><i>FfxFsr2Pass</i></c>. For a
+/// more comprehensive description of each pass, please refer to the FSR2
+/// reference documentation.
+///
+/// Please note in some cases e.g.: <c><i>FFX_FSR2_PASS_ACCUMULATE</i></c>
+/// and <c><i>FFX_FSR2_PASS_ACCUMULATE_SHARPEN</i></c> either one pass or the
+/// other will be used (they are mutually exclusive). The choice of which will
+/// depend on the way the <c><i>FfxFsr2Context</i></c> is created and the
+/// precise contents of <c><i>FfxFsr2DispatchParamters</i></c> each time a call
+/// is made to <c><i>ffxFsr2ContextDispatch</i></c>.
+/// 
+/// @ingroup FSR2
+typedef enum FfxFsr2Pass {
+
+    FFX_FSR2_PASS_PREPARE_INPUT_COLOR = 0,                              ///< A pass which prepares input colors for subsequent use.
+    FFX_FSR2_PASS_DEPTH_CLIP = 1,                                       ///< A pass which performs depth clipping.
+    FFX_FSR2_PASS_RECONSTRUCT_PREVIOUS_DEPTH = 2,                       ///< A pass which performs reconstruction of previous frame's depth.
+    FFX_FSR2_PASS_LOCK = 3,                                             ///< A pass which calculates pixel locks.
+    FFX_FSR2_PASS_ACCUMULATE = 4,                                       ///< A pass which performs upscaling.
+    FFX_FSR2_PASS_ACCUMULATE_SHARPEN = 5,                               ///< A pass which performs upscaling when sharpening is used.
+    FFX_FSR2_PASS_RCAS = 6,                                             ///< A pass which performs sharpening.
+    FFX_FSR2_PASS_COMPUTE_LUMINANCE_PYRAMID = 7,                        ///< A pass which generates the luminance mipmap chain for the current frame.
+    FFX_FSR2_PASS_GENERATE_REACTIVE = 8,                                ///< An optional pass to generate a reactive mask
+
+    FFX_FSR2_PASS_COUNT                                                 ///< The number of passes performed by FSR2.
+} FfxFsr2Pass;
+
 /// An enumeration of surface formats.
 typedef enum FfxSurfaceFormat {
 
@@ -238,7 +270,8 @@ typedef struct FfxResourceBinding
 
 /// A structure encapsulating a single pass of an algorithm.
 typedef struct FfxPipelineState {
-
+    
+    FfxFsr2Pass                     passId;
     FfxRootSignature                rootSignature;                                  ///< The pipelines rootSignature
     FfxPipeline                     pipeline;                                       ///< The pipeline object
     uint32_t                        uavCount;                                       ///< Count of UAVs used in this pipeline


### PR DESCRIPTION
Added functionality for identifying which FSR2 pass should be executed in for example [FfxFsr2ExecuteGpuJobsFunc](https://github.com/GPUOpen-Effects/FidelityFX-FSR2/blob/master/src/ffx-fsr2-api/ffx_fsr2_interface.h#L290-L312)

I've made this change locally when implementing my own rendering backend for FSR2. our backend does not directly expose Command Lists so this change was very useful for us and so I also made it a PR for your consideration. The change is very small and does not impact the algorithm in any way but it does require moving the definition of FfxFsr2Pass from ffx_interface.h to ffx_types.h
