### PR TITLE
GLSL: Don't bind PreparedImage as SRV in depth clip shader

### DIFF
--- a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip_pass.glsl
+++ b/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip_pass.glsl
@@ -29,18 +29,17 @@
 #define FSR2_BIND_SRV_DILATED_DEPTH                         2
 #define FSR2_BIND_SRV_REACTIVE_MASK                         3
 #define FSR2_BIND_SRV_TRANSPARENCY_AND_COMPOSITION_MASK     4
-#define FSR2_BIND_SRV_PREPARED_INPUT_COLOR                  5
-#define FSR2_BIND_SRV_PREVIOUS_DILATED_MOTION_VECTORS       6
-#define FSR2_BIND_SRV_INPUT_MOTION_VECTORS                  7
-#define FSR2_BIND_SRV_INPUT_COLOR                           8
-#define FSR2_BIND_SRV_INPUT_DEPTH                           9
-#define FSR2_BIND_SRV_INPUT_EXPOSURE                        10
+#define FSR2_BIND_SRV_PREVIOUS_DILATED_MOTION_VECTORS       5
+#define FSR2_BIND_SRV_INPUT_MOTION_VECTORS                  6
+#define FSR2_BIND_SRV_INPUT_COLOR                           7
+#define FSR2_BIND_SRV_INPUT_DEPTH                           8
+#define FSR2_BIND_SRV_INPUT_EXPOSURE                        9
 
-#define FSR2_BIND_UAV_DEPTH_CLIP                            11
-#define FSR2_BIND_UAV_DILATED_REACTIVE_MASKS                12
-#define FSR2_BIND_UAV_PREPARED_INPUT_COLOR                  13
+#define FSR2_BIND_UAV_DEPTH_CLIP                            10
+#define FSR2_BIND_UAV_DILATED_REACTIVE_MASKS                11
+#define FSR2_BIND_UAV_PREPARED_INPUT_COLOR                  12
 
-#define FSR2_BIND_CB_FSR2                                   14
+#define FSR2_BIND_CB_FSR2                                   13
 
 #include "ffx_fsr2_callbacks_glsl.h"
 #include "ffx_fsr2_common.h"


### PR DESCRIPTION
The GLSL version of the depth clip pass binds the image "PreparedInputColor" as both an SRV and a UAV.

https://github.com/GPUOpen-Effects/FidelityFX-FSR2/blob/master/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip_pass.glsl#L32
https://github.com/GPUOpen-Effects/FidelityFX-FSR2/blob/master/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip_pass.glsl#LL41C9-L41C61

The Vulkan backend transitions all SRVs to IMAGE_LAYOUT_SHADER_READ_ONLY and all UAVs to IMAGE_LAYOUT_GENERAL. SRV layout transitions are added after the UAV ones and SRV descriptors are set to use IMAGE_LAYOUT_SHADER_READ_ONLY, so even if we assume that layout transitions are serialized and the shader never actually writes to the UAV, this is still a bug.

The HLSL equivalent does not try to bind the SRV of PreparedInputColor and the underlying shader only ever needs the UAV one (write only even). 